### PR TITLE
feat(infra): ECS 기반 Backend 배포 환경 구성

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -1,0 +1,126 @@
+resource "aws_security_group" "ecs_instance" {
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  ingress {
+    description = "SSH access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = "ticketing-cluster"
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "ticketing-task"
+  requires_compatibilities = ["FARGATE"]
+  network_mode            = "awsvpc"
+  cpu                     = "512"
+  memory                  = "1024"
+  execution_role_arn      = aws_iam_role.ecs_task_execution.arn
+
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "backend"
+      image     = var.ecr_image,
+      essential = true
+      portMappings = [
+        {
+          containerPort = 8080
+          protocol      = "tcp"
+        }
+      ]
+    }
+  ])
+
+}
+
+# ALB
+resource "aws_lb" "this" {
+  name               = "ticketing-lb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.lb.id]
+  subnets            = aws_subnet.public[*].id
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = "ticketing-tg"
+  port        = 8080  #80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+
+  health_check {
+    path                = "/healthcheck"
+    matcher             = "200-499"
+    interval            = 30
+    timeout             = 20 #10
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+  }
+}
+
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+# ECS Service
+resource "aws_ecs_service" "this" {
+  name            = "ticketing-service"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = 2
+  launch_type     = "FARGATE"
+  
+  network_configuration {
+    subnets          = aws_subnet.public[*].id
+    security_groups  = [aws_security_group.ecs_instance.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = "backend"
+    container_port   = 8080
+  }
+
+  depends_on = [aws_lb_listener.this]
+}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -22,3 +22,54 @@ resource "aws_security_group" "database_sg" {
     Name = "uni-schedule database security group"
   }
 }
+
+resource "aws_security_group" "lb" {
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "uni-schedule lb security group"
+  }
+}
+
+resource "aws_security_group" "ecs_instance" {
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  ingress {
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "uni-schedule ecs security group"
+  }
+}


### PR DESCRIPTION
# 연관된 이슈
- Closes #14 

# 해결하려는 문제가 무엇인가요?
- Backend 애플리케이션을 실제로 배포/운영할 수 있는 환경(ECS + ALB + 로그)이 필요함

# 어떻게 해결했나요?
- ECS Cluster, Task Definition, Service 리소스 추가
- ALB + Target Group + Listener 구성 및 ECS와 연동
- DB 연결 정보를 SSM Parameter Store에서 읽어 ECS 컨테이너 환경변수로 주입
- CloudWatch Log Group 생성 및 ECS 로그 설정 추가
- Health Check Grace Period(300초) 적용으로 초기 구동 안정성 강화

# 어떤 부분에 집중하여 리뷰해야 할까요?
- ECS Task Definition의 환경변수(DB 접속 정보) 주입 방식이 적절한지
- ALB Target Group Health Check 경로(`/actuator/health`) 설정이 맞는지
- 보안 그룹 구성(DB → ECS, ALB → ECS) 규칙이 적절한지
