### PR TITLE
feat: 원격 상태 관리용 S3 버킷 추가

### DIFF
--- a/infra/remote-state.tf
+++ b/infra/remote-state.tf
@@ -1,3 +1,12 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "remote_state" {
+  bucket = "uni-schedule-remote-state-bucket"
+
+  tags = {
+    Name    = "uni-schedule-remote-state-bucket"
+    Project = "uni-schedule"
+  }
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -7,4 +7,11 @@ terraform {
       version = "~> 6.11"
     }
   }
+
+  backend "s3" {
+    bucket       = "uni-schedule-remote-state-bucket"
+    key          = "terraform/state"
+    region       = "ap-northeast-2"
+    use_lockfile = true
+  }
 }


### PR DESCRIPTION
# 연관된 이슈
- Closes #30 

# 해결하려는 문제가 무엇인가요?
- Terraform state 원격 관리 필요

# 어떻게 해결했나요?
- 원격 상태 관리를 위한 S3 버킷과 data 블록 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Terraform to store state remotely in cloud storage.
  * Provisioned a dedicated storage bucket for Terraform state.
  * Updated backend settings to point to the remote state.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->