### PR TITLE
fix: ECS TaskDefinition 누락된 시크릿 추가

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_task_definition" "this" {
   memory             = "512"
   execution_role_arn = aws_iam_role.ecs_task_execution.arn
   task_role_arn      = aws_iam_role.ecs_task.arn
-  
+
   container_definitions = jsonencode([
     {
       name      = "backend"
@@ -33,7 +33,8 @@ resource "aws_ecs_task_definition" "this" {
       secrets = [
         { name = "SPRING_DATASOURCE_USERNAME", valueFrom = data.aws_ssm_parameter.db_username.arn },
         { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = data.aws_ssm_parameter.db_password.arn },
-        { name = "JWT_SECRET", valueFrom = data.aws_ssm_parameter.jwt_secret.arn }
+        { name = "JWT_SECRET", valueFrom = data.aws_ssm_parameter.jwt_secret.arn },
+        { name = "OPENAI_API_KEY", valueFrom = data.aws_ssm_parameter.openai_api_key.arn }
       ]
 
       logConfiguration = {

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -55,7 +55,8 @@ resource "aws_iam_role_policy" "ecs_task_execution_ssm" {
         Resource = [
           data.aws_ssm_parameter.db_username.arn,
           data.aws_ssm_parameter.db_password.arn,
-          data.aws_ssm_parameter.jwt_secret.arn
+          data.aws_ssm_parameter.jwt_secret.arn,
+          data.aws_ssm_parameter.openai_api_key.arn
         ]
       }
     ]

--- a/infra/ssm.tf
+++ b/infra/ssm.tf
@@ -23,3 +23,8 @@ data "aws_ssm_parameter" "jwt_access_token_timeout_sec" {
 data "aws_ssm_parameter" "jwt_refresh_token_timeout_sec" {
   name = "/uni-schedule/config/jwt_refresh_token_timeout_sec"
 }
+
+data "aws_ssm_parameter" "openai_api_key" {
+  name            = "/uni-schedule/config/openai_api_key"
+  with_decryption = true
+}


### PR DESCRIPTION
# 연관된 이슈
- Closes #33 

# 해결하려는 문제가 무엇인가요?
- OPENAI_API_KEY 환경변수 누락으로 컨테이너 실행 실패 발생

# 어떻게 해결했나요?
- ECS TaskDefinition에 OPENAI_API_KEY 시크릿을 추가하여 SSM에서 불러오도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled secure retrieval of an additional API key at runtime via parameter store.
  * Updated task permissions to allow access to the new encrypted parameter.
  * Adjusted container secret configuration to include the new key.
  * Minor formatting cleanup in infrastructure configuration.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->