### PR TITLE
회원가입/액세스 토큰 재발급 오류 수정

### DIFF
--- a/backend/src/main/java/unischedule/auth/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/unischedule/auth/jwt/JwtTokenProvider.java
@@ -65,8 +65,10 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .subject(authentication.getName())
+                .claim("auth", authorities)
                 .issuedAt(now)
                 .expiration(validity)
+                .signWith(secretKey)
                 .compact();
     }
 

--- a/backend/src/main/java/unischedule/member/controller/MemberApiController.java
+++ b/backend/src/main/java/unischedule/member/controller/MemberApiController.java
@@ -8,10 +8,10 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import unischedule.auth.jwt.JwtTokenProvider;
 import unischedule.auth.service.RefreshTokenService;
 import unischedule.member.dto.AccessTokenRefreshRequestDto;
@@ -20,7 +20,7 @@ import unischedule.member.dto.MemberRegistrationDto;
 import unischedule.member.dto.MemberTokenResponseDto;
 import unischedule.member.service.MemberService;
 
-@Controller
+@RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
 public class MemberApiController {
@@ -44,7 +44,7 @@ public class MemberApiController {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
-        String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
+        String refreshToken = refreshTokenService.issueRefreshToken(authentication);
 
         return ResponseEntity.ok(new MemberTokenResponseDto(accessToken, refreshToken));
     }

--- a/backend/src/main/java/unischedule/member/entity/Member.java
+++ b/backend/src/main/java/unischedule/member/entity/Member.java
@@ -25,7 +25,7 @@ public class Member {
     private String nickname;
     @Column(nullable = false, updatable = false, length = 50)
     private String email;
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, length = 255)
     private String password;
     @CreatedDate
     private LocalDateTime createdAt;

--- a/backend/src/test/java/unischedule/member/controller/MemberApiControllerTest.java
+++ b/backend/src/test/java/unischedule/member/controller/MemberApiControllerTest.java
@@ -92,7 +92,7 @@ class MemberApiControllerTest {
         //AuthenticationManager mockAuthenticationManager = mock(AuthenticationManager.class);
         given(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class))).willReturn(authentication);
         given(jwtTokenProvider.createAccessToken(any(Authentication.class))).willReturn("test-access-token");
-        given(jwtTokenProvider.createRefreshToken(any(Authentication.class))).willReturn("test-refresh-token");
+        given(refreshTokenService.issueRefreshToken(any(Authentication.class))).willReturn("test-refresh-token");
 
 
         // when & then


### PR DESCRIPTION
# 연관된 이슈
- #35

# 해결하려는 문제가 무엇인가요?
- 회원가입 시 비밀번호 암호화 적용으로 인해 length가 달라져서 DB 제약조건을 위반하는 에러가 발생했습니다.
- 리프레시 토큰이 정상적으로 서명되고 저장되지 않아서 액세스 토큰 재발급 시 리프레시 토큰 인증이 항상 실패하는 문제가 있었습니다.
# 어떻게 해결했나요?
- password 필드의 length를 255로 수정했습니다.
- 리프레시 토큰 생성 시 DB에 저장하도록 의도된 refreshTokenService.issueRefreshToken() 을 사용했습니다.
- 리프레시 토큰 생성 로직에서 누락된 signWith()를 추가했습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 기능 동작 모두 확인했고 API 명세에 현재 반영된 부분까지 작성해뒀습니다.
- Spring Security에서 처리되지 않은 예외가 모두 403으로 반환되는데, 로그인 관련 오류는 추후 401을 반환하도록 수정해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - API endpoints now return JSON responses by default.
  - Refresh tokens are now cryptographically signed and include authorization details for improved reliability.
  - Support for longer passwords (up to 255 characters).

- Refactor
  - Delegated refresh token issuance to a dedicated service for clearer responsibility separation.

- Tests
  - Updated authentication tests to reflect the new refresh token issuance flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->