### PR TITLE
Feat: 팀 기능 구현

### DIFF
--- a/backend/src/main/java/unischedule/team/controller/TeamController.java
+++ b/backend/src/main/java/unischedule/team/controller/TeamController.java
@@ -1,0 +1,27 @@
+package unischedule.team.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import unischedule.team.service.TeamService;
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+    
+    private final TeamService teamService;
+    
+    @PostMapping
+    ResponseEntity<TeamCreateResponseDto> createTeam(
+        @RequestBody TeamCreateRequestDto requestDto
+        //헤더에서 유저 정보 파싱해와 아이디 얻어오는거 추가 필요
+    ) {
+        TeamCreateResponseDto responseDto = teamService.createTeam(requestDto);
+        return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+    }
+}

--- a/backend/src/main/java/unischedule/team/controller/TeamController.java
+++ b/backend/src/main/java/unischedule/team/controller/TeamController.java
@@ -1,5 +1,6 @@
 package unischedule.team.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class TeamController {
     
     @PostMapping
     ResponseEntity<TeamCreateResponseDto> createTeam(
-        @RequestBody TeamCreateRequestDto requestDto,
+        @RequestBody @Valid TeamCreateRequestDto requestDto,
         @AuthenticationPrincipal UserDetails userDetails
     ) {
         TeamCreateResponseDto responseDto = teamService.createTeam(userDetails.getUsername(), requestDto);
@@ -33,7 +34,7 @@ public class TeamController {
     
     @PostMapping("/join")
     ResponseEntity<TeamJoinResponseDto> joinTeam(
-        @RequestBody TeamJoinRequestDto requestDto,
+        @RequestBody @Valid TeamJoinRequestDto requestDto,
         @AuthenticationPrincipal UserDetails userDetails
     ) {
         TeamJoinResponseDto responseDto = teamService.joinTeam(userDetails.getUsername(), requestDto);

--- a/backend/src/main/java/unischedule/team/controller/TeamController.java
+++ b/backend/src/main/java/unischedule/team/controller/TeamController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import unischedule.team.dto.TeamCreateRequestDto;
+import unischedule.team.dto.TeamCreateResponseDto;
 import unischedule.team.service.TeamService;
 
 @RestController

--- a/backend/src/main/java/unischedule/team/controller/TeamController.java
+++ b/backend/src/main/java/unischedule/team/controller/TeamController.java
@@ -3,12 +3,16 @@ package unischedule.team.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import unischedule.team.dto.TeamCreateRequestDto;
 import unischedule.team.dto.TeamCreateResponseDto;
+import unischedule.team.dto.TeamJoinRequestDto;
+import unischedule.team.dto.TeamJoinResponseDto;
 import unischedule.team.service.TeamService;
 
 @RestController
@@ -20,10 +24,19 @@ public class TeamController {
     
     @PostMapping
     ResponseEntity<TeamCreateResponseDto> createTeam(
-        @RequestBody TeamCreateRequestDto requestDto
-        //헤더에서 유저 정보 파싱해와 아이디 얻어오는거 추가 필요
+        @RequestBody TeamCreateRequestDto requestDto,
+        @AuthenticationPrincipal UserDetails userDetails
     ) {
-        TeamCreateResponseDto responseDto = teamService.createTeam(requestDto);
+        TeamCreateResponseDto responseDto = teamService.createTeam(userDetails.getUsername(), requestDto);
         return new ResponseEntity<>(responseDto, HttpStatus.CREATED);
+    }
+    
+    @PostMapping("/join")
+    ResponseEntity<TeamJoinResponseDto> joinTeam(
+        @RequestBody TeamJoinRequestDto requestDto,
+        @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        TeamJoinResponseDto responseDto = teamService.joinTeam(userDetails.getUsername(), requestDto);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/backend/src/main/java/unischedule/team/dto/TeamCreateRequestDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamCreateRequestDto.java
@@ -1,0 +1,10 @@
+package unischedule.team.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamCreateRequestDto(
+    @NotBlank
+    String name
+) {
+
+}

--- a/backend/src/main/java/unischedule/team/dto/TeamCreateResponseDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamCreateResponseDto.java
@@ -1,0 +1,9 @@
+package unischedule.team.dto;
+
+public record TeamCreateResponseDto(
+    Long teamId,
+    String teamName,
+    String teamCode
+) {
+
+}

--- a/backend/src/main/java/unischedule/team/dto/TeamJoinRequestDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamJoinRequestDto.java
@@ -1,0 +1,10 @@
+package unischedule.team.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamJoinRequestDto(
+    @NotBlank
+    String visitCode
+) {
+
+}

--- a/backend/src/main/java/unischedule/team/dto/TeamJoinResponseDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamJoinResponseDto.java
@@ -1,0 +1,9 @@
+package unischedule.team.dto;
+
+public record TeamJoinResponseDto(
+    Long teamId,
+    String teamName,
+    String visitCode
+) {
+
+}

--- a/backend/src/main/java/unischedule/team/entity/Team.java
+++ b/backend/src/main/java/unischedule/team/entity/Team.java
@@ -6,12 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import unischedule.common.entity.BaseEntity;
 
 @Entity
 @Getter
 @Table(name = "teams")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team extends BaseEntity {
 
     @Id
@@ -20,10 +23,6 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private String name;
     private String inviteCode;
-
-    protected Team() {
-
-    }
 
     public Team(String name, String inviteCode) {
         this.name = name;

--- a/backend/src/main/java/unischedule/team/repository/TeamRepository.java
+++ b/backend/src/main/java/unischedule/team/repository/TeamRepository.java
@@ -6,4 +6,6 @@ import unischedule.team.entity.Team;
 
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    
+    boolean existsByInviteCode(String code);
 }

--- a/backend/src/main/java/unischedule/team/repository/TeamRepository.java
+++ b/backend/src/main/java/unischedule/team/repository/TeamRepository.java
@@ -1,7 +1,9 @@
 package unischedule.team.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import unischedule.team.entity.Team;
 
+@Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
 }

--- a/backend/src/main/java/unischedule/team/repository/TeamRepository.java
+++ b/backend/src/main/java/unischedule/team/repository/TeamRepository.java
@@ -1,5 +1,6 @@
 package unischedule.team.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import unischedule.team.entity.Team;
@@ -8,4 +9,6 @@ import unischedule.team.entity.Team;
 public interface TeamRepository extends JpaRepository<Team, Long> {
     
     boolean existsByInviteCode(String code);
+    
+    Optional<Team> findByInviteCode(String s);
 }

--- a/backend/src/main/java/unischedule/team/service/TeamCodeGenerator.java
+++ b/backend/src/main/java/unischedule/team/service/TeamCodeGenerator.java
@@ -1,0 +1,25 @@
+package unischedule.team.service;
+
+import java.security.SecureRandom;
+
+public class TeamCodeGenerator {
+    
+    //팀 코드 길이 변환 필요 시 조정
+    private static final int DEFAULT_LENGTH = 6;
+    
+    //특수 문자 추가 원할 시 추가 가능
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+    private final SecureRandom secureRandom = new SecureRandom();
+    
+    public String generateRandomCode() {
+        StringBuilder sb = new StringBuilder();
+        
+        for (int i = 0; i < DEFAULT_LENGTH; i++) {
+            int index = secureRandom.nextInt(CHARACTERS.length());
+            sb.append(CHARACTERS.charAt(index));
+        }
+        
+        return sb.toString();
+    }
+    
+}

--- a/backend/src/main/java/unischedule/team/service/TeamCodeGenerator.java
+++ b/backend/src/main/java/unischedule/team/service/TeamCodeGenerator.java
@@ -11,7 +11,7 @@ public class TeamCodeGenerator {
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
     private final SecureRandom secureRandom = new SecureRandom();
     
-    public String generateRandomCode() {
+    public String generate() {
         StringBuilder sb = new StringBuilder();
         
         for (int i = 0; i < DEFAULT_LENGTH; i++) {

--- a/backend/src/main/java/unischedule/team/service/TeamService.java
+++ b/backend/src/main/java/unischedule/team/service/TeamService.java
@@ -53,6 +53,7 @@ public class TeamService {
         /*
         팀과 개인의 연관관계 구현해서 저장하는 코드 추가 필요 (중계 테이블 필요 때문에 반드시 소통 필요)
         나 - 생성된 팀 연관관계를 테이블에 저장
+        멘토링 내용에 대해 의논 후 구현할 필요가 있을 듯
          */
         
         Calendar teamCalendar = new Calendar(
@@ -85,6 +86,7 @@ public class TeamService {
         /*
         팀과 개인의 연관관계 구현해서 저장하는 코드 추가 필요
         나 - 검색한 팀 연관관계를 테이블에 저장
+        멘토링 내용에 대해 의논 후 구현할 필요가 있을 듯
          */
         
         return new TeamJoinResponseDto(

--- a/backend/src/main/java/unischedule/team/service/TeamService.java
+++ b/backend/src/main/java/unischedule/team/service/TeamService.java
@@ -1,8 +1,37 @@
 package unischedule.team.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import unischedule.team.dto.TeamCreateRequestDto;
+import unischedule.team.dto.TeamCreateResponseDto;
+import unischedule.team.entity.Team;
+import unischedule.team.repository.TeamRepository;
 
 @Service
+@RequiredArgsConstructor
 public class TeamService {
-
+    
+    private final TeamRepository teamRepository;
+    
+    @Transactional
+    public TeamCreateResponseDto createTeam(TeamCreateRequestDto requestDto) {
+        
+        TeamCodeGenerator teamCodeGenerator = new TeamCodeGenerator();
+        
+        String code;
+        do {
+            code = teamCodeGenerator.generate();
+        } while (teamRepository.existsByInviteCode(code));
+        
+        Team newTeam = new Team(requestDto.name(), code);
+        
+        Team saved = teamRepository.save(newTeam);
+        
+        return new TeamCreateResponseDto(
+            saved.getTeamId(),
+            saved.getName(),
+            saved.getInviteCode()
+        );
+    }
 }

--- a/backend/src/main/java/unischedule/team/service/TeamService.java
+++ b/backend/src/main/java/unischedule/team/service/TeamService.java
@@ -51,12 +51,13 @@ public class TeamService {
         Team saved = teamRepository.save(newTeam);
         
         /*
-        // 팀과 개인의 연관관계 구현해서 저장하는 코드 추가 필요 (중계 테이블 필요 때문에 반드시 소통 필요)
+        팀과 개인의 연관관계 구현해서 저장하는 코드 추가 필요 (중계 테이블 필요 때문에 반드시 소통 필요)
+        나 - 생성된 팀 연관관계를 테이블에 저장
          */
         
         Calendar teamCalendar = new Calendar(
             findMember, saved, "팀 캘린더", "팀 캘린더입니다."
-        ); //유저 정보 불러오기 필요
+        );
         
         calendarRepository.save(teamCalendar);
         
@@ -78,8 +79,12 @@ public class TeamService {
         Team findTeam = teamRepository.findByInviteCode(requestDto.visitCode())
             .orElseThrow(() -> new EntityNotFoundException("요청한 정보의 팀이 없습니다."));
         
+        Member findMember = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new EntityNotFoundException("해당 멤버가 없습니다."));
+        
         /*
         팀과 개인의 연관관계 구현해서 저장하는 코드 추가 필요
+        나 - 검색한 팀 연관관계를 테이블에 저장
          */
         
         return new TeamJoinResponseDto(

--- a/backend/src/main/java/unischedule/team/service/TeamService.java
+++ b/backend/src/main/java/unischedule/team/service/TeamService.java
@@ -3,23 +3,45 @@ package unischedule.team.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import unischedule.calendar.entity.Calendar;
+import unischedule.calendar.repository.CalendarRepository;
+import unischedule.exception.EntityNotFoundException;
+import unischedule.member.entity.Member;
+import unischedule.member.repository.MemberRepository;
 import unischedule.team.dto.TeamCreateRequestDto;
 import unischedule.team.dto.TeamCreateResponseDto;
+import unischedule.team.dto.TeamJoinRequestDto;
+import unischedule.team.dto.TeamJoinResponseDto;
 import unischedule.team.entity.Team;
 import unischedule.team.repository.TeamRepository;
 
+/**
+ * 팀과 관련한 서비스 메서드들의 클래스
+ */
+// 차후 개인과 팀의 연관관계 구현 후 완성 필요 (세환 씨 저랑 이야기 좀 해요)
 @Service
 @RequiredArgsConstructor
 public class TeamService {
     
     private final TeamRepository teamRepository;
+    private final CalendarRepository calendarRepository;
+    private final MemberRepository memberRepository;
     
+    /**
+     * 팀 생성을 위한 메서드
+     * @param email 헤더에서 얻어온 유저 이메일
+     * @param requestDto 생성 요청 Dto, 팀 이름에 대한 정보 포함
+     * @return 팀 생성된 결과를 담은 Dto
+     */
     @Transactional
-    public TeamCreateResponseDto createTeam(TeamCreateRequestDto requestDto) {
+    public TeamCreateResponseDto createTeam(String email, TeamCreateRequestDto requestDto) {
         
         TeamCodeGenerator teamCodeGenerator = new TeamCodeGenerator();
-        
         String code;
+        
+        Member findMember = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new EntityNotFoundException("해당 멤버가 없습니다."));
+        
         do {
             code = teamCodeGenerator.generate();
         } while (teamRepository.existsByInviteCode(code));
@@ -28,10 +50,42 @@ public class TeamService {
         
         Team saved = teamRepository.save(newTeam);
         
+        /*
+        // 팀과 개인의 연관관계 구현해서 저장하는 코드 추가 필요 (중계 테이블 필요 때문에 반드시 소통 필요)
+         */
+        
+        Calendar teamCalendar = new Calendar(
+            findMember, saved, "팀 캘린더", "팀 캘린더입니다."
+        ); //유저 정보 불러오기 필요
+        
+        calendarRepository.save(teamCalendar);
+        
         return new TeamCreateResponseDto(
             saved.getTeamId(),
             saved.getName(),
             saved.getInviteCode()
+        );
+    }
+    
+    /**
+     *
+     * @param email 헤더에서 넘어온 유저 이메일
+     * @param requestDto 팀 코드 요청
+     * @return 가입된 팀의 정보
+     */
+    public TeamJoinResponseDto joinTeam(String email, TeamJoinRequestDto requestDto) {
+        
+        Team findTeam = teamRepository.findByInviteCode(requestDto.visitCode())
+            .orElseThrow(() -> new EntityNotFoundException("요청한 정보의 팀이 없습니다."));
+        
+        /*
+        팀과 개인의 연관관계 구현해서 저장하는 코드 추가 필요
+         */
+        
+        return new TeamJoinResponseDto(
+            findTeam.getTeamId(),
+            findTeam.getName(),
+            findTeam.getInviteCode()
         );
     }
 }

--- a/backend/src/main/java/unischedule/team/service/TeamService.java
+++ b/backend/src/main/java/unischedule/team/service/TeamService.java
@@ -1,0 +1,8 @@
+package unischedule.team.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TeamService {
+
+}


### PR DESCRIPTION
# 연관된 이슈
- #39 

# 해결하려는 문제가 무엇인가요?
- 팀 캘린더 기능 구현을 위한 팀 기능 구현

# 어떻게 해결했나요?
- 팀 Entity 보수
- 팀 생성 시 6자리의 랜덤 코드 생성 (길이는 차후 조율 가능) 및 테이블에 저장 구현 (현재는 고정)
- 팀 코드 입력 시 팀을 찾는 것까지는 구현
- 팀 생성 / 팀 가입에 대한 기능 80퍼센트 구현
- 팀 삭제 필요시 구현할 예정

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 현재 "팀-개인 연관관계" 테이블 미구현 상태여서, 기능 자체는 아직 미완성 (팀-개인 연관관계 형성 후 테이블에 저장하는 것만 구현하면 팀 생성/가입은 완전구현)
- 다만 멘토링에서 들은 얘기에 따라 중간 테이블을 위한 도메인을 따로 만들어야 하나 하는 의구심이 있어서, 그 부분에 대해 이야기할 필요는 있음
- 현재 Service package에 TeamCodeGernerator 라는 이름의 객체가 만들어져 있음. 해당 객체의 위치? 이런 거에 대해 의견을 줘도 괜찮고, 코드 상 도메인 로직으로 뺄만한 부분이 있다면 그 부분도 얘기해 주면 좋을 듯

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create a team and receive its ID, name, and invite (join) code.
  - Join an existing team using an invite code and receive confirmation details.
  - Automatic initial calendar is created for newly created teams.
  - Input validation ensures team name and invite code are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->