### PR TITLE
feat: GlobalExceptionHander에 예외 처리 추가

### DIFF
--- a/backend/src/main/java/unischedule/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/unischedule/exception/GlobalExceptionHandler.java
@@ -3,7 +3,6 @@ package unischedule.exception;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.util.stream.Collectors;
-import org.springframework.boot.autoconfigure.graphql.GraphQlProperties.Http;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -51,6 +50,11 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
 
         return ResponseEntity.badRequest().body(ErrorResponseDto.of(message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleGeneralException(Exception ex) {
+        return ResponseEntity.internalServerError().body(ErrorResponseDto.of(ex.getMessage())); //TODO: 실 배포 시 메시지 변경
     }
 }
 

--- a/backend/src/main/java/unischedule/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/unischedule/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.validation.ConstraintViolationException;
 import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import unischedule.exception.dto.EntityAlreadyExistsException;
@@ -47,6 +48,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDto> constraintValidationException(ConstraintViolationException ex) {
         String message = ex.getConstraintViolations().stream()
                 .map(ConstraintViolation::getMessage)
+                .collect(Collectors.joining(", "));
+
+        return ResponseEntity.badRequest().body(ErrorResponseDto.of(message));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
 
         return ResponseEntity.badRequest().body(ErrorResponseDto.of(message));


### PR DESCRIPTION
# 연관된 이슈
- #53 

# 해결하려는 문제가 무엇인가요?
- 기타 모든 예외에 대해 internal server exception 및 오류 메시지 띄우도록 변경

# 어떻게 해결했나요?
- GlobalExceptionHandler에 모든 기타 예외 잡는 메서드 추가 (500)
- MethodArgumentNotValidException에 대한 핸들러도 추가(400)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation errors now return a clear, consolidated message listing field-specific issues and a 400 Bad Request, so users see precise guidance for correcting input.
  * Unexpected server errors are handled globally and return a consistent 500 response with an explanatory message, improving stability and user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->