### PR TITLE
Feat/52 today upcoming

### DIFF
--- a/backend/src/main/java/unischedule/events/controller/PersonalEventController.java
+++ b/backend/src/main/java/unischedule/events/controller/PersonalEventController.java
@@ -77,4 +77,22 @@ public class PersonalEventController {
         eventService.deletePersonalEvent(userDetails.getUsername(), eventId);
         return ResponseEntity.noContent().build();
     }
+    
+    @GetMapping("/upcomming")
+    public ResponseEntity<List<EventGetResponseDto>> upcomingMyEvent(
+        @AuthenticationPrincipal
+        UserDetails userDetails
+    ) {
+        List<EventGetResponseDto> upcomingList = eventService.getUpcomingMyEvent(userDetails.getUsername());
+        return ResponseEntity.ok(upcomingList);
+    }
+    
+    @GetMapping("/today")
+    public ResponseEntity<List<EventGetResponseDto>> todayMyEvent(
+        @AuthenticationPrincipal
+        UserDetails userDetails
+    ) {
+        List<EventGetResponseDto> upcomingList = eventService.getTodayMyEvent(userDetails.getUsername());
+        return ResponseEntity.ok(upcomingList);
+    }
 }

--- a/backend/src/main/java/unischedule/events/repository/EventRepository.java
+++ b/backend/src/main/java/unischedule/events/repository/EventRepository.java
@@ -2,6 +2,7 @@ package unischedule.events.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -82,4 +83,14 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             @Param("eventId")
             Long eventId
     );
+    
+    @Query("""
+            SELECT e FROM Event e
+            WHERE e.calendar.owner.memberId = :memberId
+            AND e.startAt >= :now
+            ORDER BY e.startAt ASC
+    """)
+    List<Event> findUpcomingEvents(@Param("memberId") Long memberId,
+        @Param("now") LocalDateTime now,
+        Pageable pageable);
 }

--- a/backend/src/main/java/unischedule/events/service/PersonalEventService.java
+++ b/backend/src/main/java/unischedule/events/service/PersonalEventService.java
@@ -100,4 +100,20 @@ public class PersonalEventService {
 
         eventDomainService.deleteEvent(event);
     }
+    
+    public List<EventGetResponseDto> getUpcomingMyEvent(String email) {
+        Member member = memberDomainService.findMemberByEmail(email);
+        
+        List<Event> upcomingEvents = eventDomainService.findUpcomingEventsByMember(member);
+        
+        return upcomingEvents.stream().map(EventGetResponseDto::from).toList();
+    }
+    
+    public List<EventGetResponseDto> getTodayMyEvent(String email) {
+        Member member = memberDomainService.findMemberByEmail(email);
+        
+        List<Event> todayEvents = eventDomainService.findTodayEventsByMember(member);
+        
+        return todayEvents.stream().map(EventGetResponseDto::from).toList();
+    }
 }

--- a/backend/src/main/java/unischedule/events/service/internal/EventDomainService.java
+++ b/backend/src/main/java/unischedule/events/service/internal/EventDomainService.java
@@ -51,4 +51,13 @@ public class EventDomainService {
             throw new InvalidInputException("해당 시간에 겹치는 일정이 있어 수정할 수 없습니다.");
         }
     }
+    
+    @Transactional(readOnly = true)
+    public List<Event> findUpcomingEventsByMember(Member member) {
+        return null;
+    }
+    
+    public List<Event> findTodayEventsByMember(Member member) {
+        return null;
+    }
 }

--- a/backend/src/main/java/unischedule/events/service/internal/EventDomainService.java
+++ b/backend/src/main/java/unischedule/events/service/internal/EventDomainService.java
@@ -1,6 +1,9 @@
 package unischedule.events.service.internal;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import unischedule.events.entity.Event;
@@ -54,11 +57,16 @@ public class EventDomainService {
     
     @Transactional(readOnly = true)
     public List<Event> findUpcomingEventsByMember(Member member) {
-        return null;
+        LocalDateTime now = LocalDateTime.now();
+        Pageable pageable = PageRequest.of(0, 3); // 개수 제한
+        return eventRepository.findUpcomingEvents(member.getMemberId(), now, pageable);
     }
     
     @Transactional(readOnly = true)
     public List<Event> findTodayEventsByMember(Member member) {
-        return null;
+        LocalDate today = LocalDate.now();
+        LocalDateTime startOfDay = today.atStartOfDay();              // 오늘 00:00
+        LocalDateTime endOfDay = today.plusDays(1).atStartOfDay();    // 내일 00:00
+        return eventRepository.findPersonalScheduleInPeriod(member.getMemberId(), startOfDay, endOfDay);
     }
 }

--- a/backend/src/main/java/unischedule/events/service/internal/EventDomainService.java
+++ b/backend/src/main/java/unischedule/events/service/internal/EventDomainService.java
@@ -57,6 +57,7 @@ public class EventDomainService {
         return null;
     }
     
+    @Transactional(readOnly = true)
     public List<Event> findTodayEventsByMember(Member member) {
         return null;
     }

--- a/backend/src/main/java/unischedule/team/dto/TeamCreateRequestDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamCreateRequestDto.java
@@ -1,10 +1,15 @@
 package unischedule.team.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record TeamCreateRequestDto(
     @NotBlank
-    String name
+    @JsonProperty("team_name")
+    String teamName,
+    
+    @JsonProperty("team_description")
+    String teamDescription
 ) {
 
 }

--- a/backend/src/main/java/unischedule/team/dto/TeamCreateResponseDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamCreateResponseDto.java
@@ -1,8 +1,18 @@
 package unischedule.team.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record TeamCreateResponseDto(
+    @JsonProperty("team_id")
     Long teamId,
+    
+    @JsonProperty("team_name")
     String teamName,
+    
+    @JsonProperty("team_description")
+    String teamDescription,
+    
+    @JsonProperty("team_code")
     String teamCode
 ) {
 

--- a/backend/src/main/java/unischedule/team/dto/TeamJoinRequestDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamJoinRequestDto.java
@@ -1,10 +1,12 @@
 package unischedule.team.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record TeamJoinRequestDto(
     @NotBlank
-    String visitCode
+    @JsonProperty("invite_code")
+    String inviteCode
 ) {
 
 }

--- a/backend/src/main/java/unischedule/team/dto/TeamJoinResponseDto.java
+++ b/backend/src/main/java/unischedule/team/dto/TeamJoinResponseDto.java
@@ -1,9 +1,14 @@
 package unischedule.team.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record TeamJoinResponseDto(
+    @JsonProperty("team_id")
     Long teamId,
+    @JsonProperty("team_name")
     String teamName,
-    String visitCode
+    @JsonProperty("team_description")
+    String teamDescription
 ) {
 
 }

--- a/backend/src/main/java/unischedule/team/entity/Team.java
+++ b/backend/src/main/java/unischedule/team/entity/Team.java
@@ -22,10 +22,12 @@ public class Team extends BaseEntity {
     private Long teamId;
     @Column(nullable = false)
     private String name;
+    private String description;
     private String inviteCode;
 
-    public Team(String name, String inviteCode) {
+    public Team(String name, String description, String inviteCode) {
         this.name = name;
+        this.description = description;
         this.inviteCode = inviteCode;
     }
 }

--- a/backend/src/main/java/unischedule/team/repository/TeamMemberRepository.java
+++ b/backend/src/main/java/unischedule/team/repository/TeamMemberRepository.java
@@ -12,4 +12,6 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByTeamAndMember(Team team, Member member);
     
     List<TeamMember> findByTeam(Team team);
+    
+    Boolean existsByTeamAndMember(Team findTeam, Member findMember);
 }

--- a/backend/src/main/java/unischedule/team/service/TeamService.java
+++ b/backend/src/main/java/unischedule/team/service/TeamService.java
@@ -49,7 +49,7 @@ public class TeamService {
             code = teamCodeGenerator.generate();
         } while (teamRepository.existsByInviteCode(code));
         
-        Team newTeam = new Team(requestDto.name(), code);
+        Team newTeam = new Team(requestDto.teamName(), requestDto.teamDescription(), code);
         
         Team saved = teamRepository.save(newTeam);
         
@@ -65,6 +65,7 @@ public class TeamService {
         return new TeamCreateResponseDto(
             saved.getTeamId(),
             saved.getName(),
+            saved.getDescription(),
             saved.getInviteCode()
         );
     }
@@ -77,7 +78,7 @@ public class TeamService {
      */
     public TeamJoinResponseDto joinTeam(String email, TeamJoinRequestDto requestDto) {
         
-        Team findTeam = teamRepository.findByInviteCode(requestDto.visitCode())
+        Team findTeam = teamRepository.findByInviteCode(requestDto.inviteCode())
             .orElseThrow(() -> new EntityNotFoundException("요청한 정보의 팀이 없습니다."));
         
         Member findMember = memberRepository.findByEmail(email).get();
@@ -92,7 +93,7 @@ public class TeamService {
         return new TeamJoinResponseDto(
             findTeam.getTeamId(),
             findTeam.getName(),
-            findTeam.getInviteCode()
+            findTeam.getDescription()
         );
     }
     

--- a/backend/src/main/java/unischedule/team/service/TeamService.java
+++ b/backend/src/main/java/unischedule/team/service/TeamService.java
@@ -82,8 +82,9 @@ public class TeamService {
         
         Member findMember = memberRepository.findByEmail(email).get();
         
-        teamMemberRepository.findByTeamAndMember(findTeam, findMember)
-            .orElseThrow(() -> new ConflictException("이미 가입된 팀입니다."));
+        if(teamMemberRepository.existsByTeamAndMember(findTeam, findMember)) {
+            throw new ConflictException("이미 가입된 멤버입니다.");
+        }
         
         TeamMember relation = new TeamMember(findTeam, findMember, "MEMBER");
         teamMemberRepository.save(relation);


### PR DESCRIPTION
# 연관된 이슈
- #52 

# 해결하려는 문제가 무엇인가요?
- 다가오는 일정 조회 구현
- 오늘의 일정 조회 구현
- 그 외 팀에서 있던 문제 수정

# 어떻게 해결했나요?
- 서버 상에서 현재의 시각을 확인한 후,
- 다가오는 일정의 경우 가장 가까운 일정 3개를 리스트로 전송
- 오늘의 일정의 경우 오늘 0시부터 내일 0시까지의 모든 일정을 조회

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 코드가 어색한 것은 없는지
- 머지된 이후 테스트 코드 작성하면서 다음주 팀 코드 / 일정 확인 코드 디버깅 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - View your upcoming personal events (up to 3) and today’s events via new endpoints.
  - Team creation and join responses now include a team description.

- **Bug Fixes**
  - Prevents duplicate team joins by detecting existing membership and returning a conflict ("이미 가입된 멤버입니다.").

- **API Changes**
  - Team-related request/response fields use snake_case JSON keys (e.g., invite_code, team_name, team_description).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->