### PR TITLE
fix(calendar): fix OnetoOne to ManyToOne for calendar_member

### DIFF
--- a/backend/src/main/java/unischedule/calendar/entity/Calendar.java
+++ b/backend/src/main/java/unischedule/calendar/entity/Calendar.java
@@ -9,6 +9,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+<<<<<<< Updated upstream
+=======
+import jakarta.persistence.OneToOne;
+>>>>>>> Stashed changes
 import jakarta.persistence.Table;
 
 import lombok.Getter;


### PR DESCRIPTION

# 해결하려는 문제가 무엇인가요?
- 캘린더 연관관계 재설정

# 어떻게 해결했나요?
- OneToOne -> ManyToOne

# 어떤 부분에 집중하여 리뷰해야 할까요?
- member는 여러 캘린더를 가질 수 있는데, 기존 연관관계가 잘못돼 있었습니다.
