### PR TITLE
fix(event): apply jsonproperty in teamId #70

### DIFF
--- a/backend/src/main/java/unischedule/events/dto/TeamEventCreateRequestDto.java
+++ b/backend/src/main/java/unischedule/events/dto/TeamEventCreateRequestDto.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 
 public record TeamEventCreateRequestDto(
         @NotNull
+        @JsonProperty("team_id")
         Long teamId,
         @NotBlank
         String title,


### PR DESCRIPTION
# 연관된 이슈
- #70 

# 해결하려는 문제가 무엇인가요?
- teamId에 JsonProperty가 적용되지 않아서 api명세와 다르게 동작하는 문제 발생

# 어떻게 해결했나요?
- 팀 일정 생성 dto의 teamId에 jsonProperty 적용



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JSON field mapping for team event creation: the teamId property is now represented as team_id in request/response payloads. API clients should send and handle team_id going forward. No other behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->