### PR TITLE
feat: ecs task에 redis 환경변수 추가

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -3,13 +3,13 @@ resource "aws_ecs_cluster" "this" {
 }
 
 resource "aws_ecs_task_definition" "this" {
-  family             = "uni-schedule-task"
+  family                   = "uni-schedule-task"
   requires_compatibilities = ["FARGATE"]
-  network_mode       = "awsvpc"
-  cpu                = "256"
-  memory             = "512"
-  execution_role_arn = aws_iam_role.ecs_task_execution.arn
-  task_role_arn      = aws_iam_role.ecs_task.arn
+  network_mode             = "awsvpc"
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
 
   container_definitions = jsonencode([
     {
@@ -27,14 +27,18 @@ resource "aws_ecs_task_definition" "this" {
       environment = [
         { name = "SPRING_DATASOURCE_URL", value = data.aws_ssm_parameter.db_url.value },
         { name = "JWT_ACCESS_TOKEN_TIMEOUT_SEC", value = data.aws_ssm_parameter.jwt_access_token_timeout_sec.value },
-        { name = "JWT_REFRESH_TOKEN_TIMEOUT_SEC", value = data.aws_ssm_parameter.jwt_refresh_token_timeout_sec.value }
+        { name = "JWT_REFRESH_TOKEN_TIMEOUT_SEC", value = data.aws_ssm_parameter.jwt_refresh_token_timeout_sec.value },
+        { name = "REDIS_HOST", value = data.aws_ssm_parameter.redis_host.value },
+        { name = "REDIS_USERNAME", value = data.aws_ssm_parameter.redis_username.value },
+        { name = "REDIS_PORT", value = "17830" }
       ]
 
       secrets = [
         { name = "SPRING_DATASOURCE_USERNAME", valueFrom = data.aws_ssm_parameter.db_username.arn },
         { name = "SPRING_DATASOURCE_PASSWORD", valueFrom = data.aws_ssm_parameter.db_password.arn },
         { name = "JWT_SECRET", valueFrom = data.aws_ssm_parameter.jwt_secret.arn },
-        { name = "OPENAI_API_KEY", valueFrom = data.aws_ssm_parameter.openai_api_key.arn }
+        { name = "OPENAI_API_KEY", valueFrom = data.aws_ssm_parameter.openai_api_key.arn },
+        { name = "REDIS_PASSWORD", valueFrom = data.aws_ssm_parameter.redis_password.arn }
       ]
 
       logConfiguration = {
@@ -53,7 +57,7 @@ resource "aws_lb" "this" {
   name               = "uni-schedule-lb"
   internal           = false
   load_balancer_type = "application"
-  security_groups = [aws_security_group.lb.id]
+  security_groups    = [aws_security_group.lb.id]
   subnets            = aws_subnet.public_subnet[*].id
 }
 
@@ -95,7 +99,7 @@ resource "aws_ecs_service" "this" {
 
   network_configuration {
     subnets          = aws_subnet.public_subnet[*].id
-    security_groups = [aws_security_group.ecs_instance.id]
+    security_groups  = [aws_security_group.ecs_instance.id]
     assign_public_ip = true
   }
 

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -56,7 +56,8 @@ resource "aws_iam_role_policy" "ecs_task_execution_ssm" {
           data.aws_ssm_parameter.db_username.arn,
           data.aws_ssm_parameter.db_password.arn,
           data.aws_ssm_parameter.jwt_secret.arn,
-          data.aws_ssm_parameter.openai_api_key.arn
+          data.aws_ssm_parameter.openai_api_key.arn,
+          data.aws_ssm_parameter.redis_password.arn,
         ]
       }
     ]

--- a/infra/ssm.tf
+++ b/infra/ssm.tf
@@ -28,3 +28,16 @@ data "aws_ssm_parameter" "openai_api_key" {
   name            = "/uni-schedule/config/openai_api_key"
   with_decryption = true
 }
+
+data "aws_ssm_parameter" "redis_host" {
+  name = "/uni-schedule/config/redis_host"
+}
+
+data "aws_ssm_parameter" "redis_password" {
+  name            = "/uni-schedule/config/redis_password"
+  with_decryption = true
+}
+
+data "aws_ssm_parameter" "redis_username" {
+  name = "/uni-schedule/config/redis_username"
+}


### PR DESCRIPTION
# 연관된 이슈
- Closes #84 

# 해결하려는 문제가 무엇인가요?
- ECS Task에서 Redis 연결 정보를 읽을 수 없어 환경변수 설정이 필요했습니다.

# 어떻게 해결했나요?
- Terraform ECS Task Definition에 REDIS_HOST, REDIS_PORT, REDIS_PASSWORD 환경변수를 추가했습니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 환경변수 키명과 값이 올바르게 매핑되었는지 확인해주세요.
