### PR TITLE
feat: 백엔드 HTTPS 적용 및 ALB 리다이렉트 설정

### DIFF
--- a/infra/acm.tf
+++ b/infra/acm.tf
@@ -1,0 +1,15 @@
+resource "aws_acm_certificate" "this" {
+  domain_name       = "*.uni-schedule.com"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  certificate_arn = aws_acm_certificate.this.arn
+  validation_record_fqdns = [
+    for record in aws_route53_record.cert_validation : record.fqdn
+  ]
+}

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -25,6 +25,7 @@ resource "aws_ecs_task_definition" "this" {
       ]
 
       environment = [
+        { name = "TZ", value = "Asia/Seoul" },
         { name = "SPRING_DATASOURCE_URL", value = data.aws_ssm_parameter.db_url.value },
         { name = "JWT_ACCESS_TOKEN_TIMEOUT_SEC", value = data.aws_ssm_parameter.jwt_access_token_timeout_sec.value },
         { name = "JWT_REFRESH_TOKEN_TIMEOUT_SEC", value = data.aws_ssm_parameter.jwt_refresh_token_timeout_sec.value },
@@ -84,9 +85,29 @@ resource "aws_lb_listener" "this" {
   protocol          = "HTTP"
 
   default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = aws_acm_certificate.this.arn
+
+  default_action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.this.arn
   }
+
+  depends_on = [aws_acm_certificate_validation.this]
 }
 
 resource "aws_ecs_service" "this" {

--- a/infra/route53.tf
+++ b/infra/route53.tf
@@ -1,0 +1,32 @@
+data "aws_route53_zone" "main" {
+  name         = "uni-schedule.com"
+  private_zone = false
+}
+
+resource "aws_route53_record" "backend" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "backend.uni-schedule.com"
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.this.dns_name
+    zone_id                = aws_lb.this.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.this.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 60
+  records = [each.value.record]
+}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -12,9 +12,9 @@ resource "aws_security_group" "database_sg" {
   }
 
   egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -27,16 +27,23 @@ resource "aws_security_group" "lb" {
   vpc_id = aws_vpc.this.id
 
   ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -49,16 +56,16 @@ resource "aws_security_group" "ecs_instance" {
   vpc_id = aws_vpc.this.id
 
   ingress {
-    from_port = 8080
-    to_port   = 8080
-    protocol  = "tcp"
+    from_port       = 8080
+    to_port         = 8080
+    protocol        = "tcp"
     security_groups = [aws_security_group.lb.id]
   }
 
   egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 


### PR DESCRIPTION
# 연관된 이슈
- Closes #105 

# 해결하려는 문제가 무엇인가요?
- 보안 및 통신 일관성 확보 필요
- HTTPS 적용 필요

# 어떻게 해결했나요?
- ACM 인증서를 발급받아 HTTPS 적용
- ALB 리스너 구성 (HTTP → HTTPS 리다이렉트, HTTPS → Target Group 포워딩)
- 보안그룹에 443 포트 허용
- Route53 도메인 연결 및 검증 완료 (`backend.uni-schedule.com`)

# 어떤 부분에 집중하여 리뷰해야 할까요?
- ALB 리스너 및 보안그룹 설정이 올바르게 구성되었는지
- HTTPS 접근 시 정상적으로 리다이렉트 및 Health Check 작동 여부

# Test
- 로컬에서 Postman을 통해 헬스체크 정상 동작 확인
<img width="491" height="235" alt="image" src="https://github.com/user-attachments/assets/e4edf8b1-cf2e-46ac-bbc6-0edcd22d939a" />
