### PR TITLE
test: 일부 테스트 코드에 Redis Mock 추가

### DIFF
--- a/backend/src/test/java/unischedule/UniScheduleApplicationTests.java
+++ b/backend/src/test/java/unischedule/UniScheduleApplicationTests.java
@@ -2,7 +2,9 @@ package unischedule;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -12,6 +14,10 @@ class UniScheduleApplicationTests {
 
     @MockitoBean
     private RedisConnectionFactory redisConnectionFactory;
+    @MockitoBean
+    private ReactiveRedisConnectionFactory reactiveRedisConnectionFactory;
+    @MockitoBean
+    private RedisMessageListenerContainer redisMessageListenerContainer;
 
     @Test
     void contextLoads() {

--- a/backend/src/test/java/unischedule/member/controller/MemberApiControllerTest.java
+++ b/backend/src/test/java/unischedule/member/controller/MemberApiControllerTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -48,6 +50,10 @@ class MemberApiControllerTest {
     private RefreshTokenService refreshTokenService;
     @MockitoBean
     private RedisConnectionFactory redisConnectionFactory;
+    @MockitoBean
+    private ReactiveRedisConnectionFactory reactiveRedisConnectionFactory;
+    @MockitoBean
+    private RedisMessageListenerContainer redisMessageListenerContainer;
 
     @Test
     @DisplayName("회원가입 - 200")


### PR DESCRIPTION
# 연관된 이슈
- #118 

# 해결하려는 문제가 무엇인가요?
- 일부 테스트 코드에 Redis Mock 추가

# 어떻게 해결했나요?
- contextLoads, memberApiControllerTest 코드에 Redis Mock 추가
