### PR TITLE
feat: ECS 서비스 CPU 기반 오토스케일링 구성 추가

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -6,8 +6,8 @@ resource "aws_ecs_task_definition" "this" {
   family                   = "uni-schedule-task"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = "256"
-  memory                   = "512"
+  cpu                      = "512"  # 256
+  memory                   = "1024" # 512
   execution_role_arn       = aws_iam_role.ecs_task_execution.arn
   task_role_arn            = aws_iam_role.ecs_task.arn
 
@@ -116,7 +116,7 @@ resource "aws_ecs_service" "this" {
   name                              = "uni-schedule-service"
   cluster                           = aws_ecs_cluster.this.id
   task_definition                   = aws_ecs_task_definition.this.arn
-  desired_count                     = 1
+  desired_count                     = 2
   launch_type                       = "FARGATE"
   health_check_grace_period_seconds = 300
 
@@ -141,5 +141,85 @@ resource "aws_cloudwatch_log_group" "backend" {
 
   tags = {
     Name = "backend-log-group"
+  }
+}
+
+resource "aws_appautoscaling_target" "ecs" {
+  max_capacity       = 5
+  min_capacity       = 2
+  resource_id        = "service/${aws_ecs_cluster.this.name}/${aws_ecs_service.this.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_cloudwatch_metric_alarm" "scale_out_alarm" {
+  alarm_name          = "scale-out-alarm"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  period              = 60
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  statistic           = "Average"
+  threshold           = 50
+  alarm_description   = "Scale out when CPU > 50% for 1 minute"
+  dimensions = {
+    ClusterName = aws_ecs_cluster.this.name
+    ServiceName = aws_ecs_service.this.name
+  }
+  alarm_actions = [aws_appautoscaling_policy.scale_out_step.arn]
+}
+
+resource "aws_appautoscaling_policy" "scale_out_step" {
+  name               = "scale-out-step"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = "ecs"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 30
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "scale_in_alarm" {
+  alarm_name          = "scale-in-alarm"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  period              = 60
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  statistic           = "Average"
+  threshold           = 20
+  alarm_description   = "Scale in when CPU < 20% for 1 minute"
+  dimensions = {
+    ClusterName = aws_ecs_cluster.this.name
+    ServiceName = aws_ecs_service.this.name
+  }
+  alarm_actions = [aws_appautoscaling_policy.scale_in_step.arn]
+}
+
+resource "aws_appautoscaling_policy" "scale_in_step" {
+  name               = "scale-in-step"
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.ecs.resource_id
+  scalable_dimension = aws_appautoscaling_target.ecs.scalable_dimension
+  service_namespace  = "ecs"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 30
+    metric_aggregation_type = "Average"
+
+    step_adjustment {
+      metric_interval_upper_bound = 0
+      scaling_adjustment          = -1
+    }
   }
 }


### PR DESCRIPTION
# 연관된 이슈
- Closes #122 

# 해결하려는 문제가 무엇인가요?
- ECS 서비스의 CPU 사용량이 일정 기준을 초과하거나 낮을 때, 수동으로 태스크 수를 조정해야 하는 불편함이 있었음
- 트래픽 증가 시 자동 확장, 감소 시 자동 축소가 필요했음

# 어떻게 해결했나요?
- Terraform을 통해 ECS 서비스에 오토스케일링 구성 추가
- `aws_appautoscaling_target` 리소스를 통해 서비스의 스케일링 범위(min=2, max=5) 지정
- CloudWatch Metric Alarm을 사용하여
  - CPU > 50% → scale out (+1 task)
  - CPU < 20% → scale in (-1 task)
- `aws_appautoscaling_policy` 리소스로 Step Scaling 정책 구성

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 오토스케일링 정책 및 알람 조건이 적절한지 (threshold, cooldown 값 등)