### PR TITLE
Fix/129 whentomeet fix

### DIFF
--- a/backend/src/main/java/unischedule/team/service/internal/WhenToMeetLogicService.java
+++ b/backend/src/main/java/unischedule/team/service/internal/WhenToMeetLogicService.java
@@ -104,18 +104,10 @@ public class WhenToMeetLogicService {
      * @return 겹치는 일정이 하나라도 있으면 true, 그렇지 않으면 false
      */
     private boolean isMemberBusyForSlot(WhenToMeet slot, List<EventGetResponseDto> events) {
-        for (EventGetResponseDto event : events) {
-            // (SlotStart < EventEnd) AND (SlotEnd > EventStart)
-            boolean isOverlap = slot.getStartTime().isBefore(event.endTime()) &&
-                slot.getEndTime().isAfter(event.startTime());
-            
-            if (isOverlap) {
-                // 하나라도 겹치면 이 멤버는 이 슬롯에서 '바쁨'
-                return true;
-            }
-        }
-        // 모든 일정을 확인했는데도 겹치지 않으면 '가능'
-        return false;
+        return events.stream().anyMatch(event ->
+            slot.getStartTime().isBefore(event.endTime()) &&
+                slot.getEndTime().isAfter(event.startTime())
+        );
     }
     
     public List<WhenToMeetResponseDto> toResponse(List<WhenToMeet> slots) {


### PR DESCRIPTION
# 연관된 이슈
- #129 

# 해결하려는 문제가 무엇인가요?
- 기존 웬투밋은 중복 일정이 없다는 가정하에 작성
- 이를 중복 일정이 있어도 동작하게끔 수정

# 어떻게 해결했나요?
- 알고리즘 로직 변경
- 기존 알고리즘은 이벤트를 불러온 다음 이벤트를 먼저 반복문의 대상으로 잡았으나 슬롯을 먼저 반복문의 대상으로 잡아 문제를 해결

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 알고리즘 동작 여부는 확인했으나 추가 확인 필요할 경우 요청
