### PR TITLE
fix: 수업으로 등록한 반복일정이 삭제되지 않는 버그 수정

### DIFF
--- a/backend/src/main/java/unischedule/events/service/common/EventCommandService.java
+++ b/backend/src/main/java/unischedule/events/service/common/EventCommandService.java
@@ -18,6 +18,7 @@ import unischedule.events.service.internal.EventRawService;
 import unischedule.events.service.internal.RecurrenceRuleRawService;
 import unischedule.events.service.internal.RecurringEventRawService;
 import unischedule.exception.InvalidInputException;
+import unischedule.lecture.repository.LectureRepository;
 
 import java.util.Optional;
 
@@ -29,6 +30,7 @@ public class EventCommandService {
     private final RecurringEventRawService recurringEventRawService;
     private final RecurrenceRuleRawService recurrenceRuleRawService;
     private final EventParticipantRawService eventParticipantRawService;
+    private final LectureRepository lectureRepository;
 
     @Transactional
     public Event createSingleEvent(
@@ -118,8 +120,8 @@ public class EventCommandService {
             throw new InvalidInputException("단일 일정이 아닙니다.");
         }
 
+        deleteLectureIfExists(eventToDelete);
         eventParticipantRawService.deleteAllByEvent(eventToDelete);
-
         eventRawService.deleteEvent(eventToDelete);
     }
 
@@ -129,9 +131,13 @@ public class EventCommandService {
             throw new InvalidInputException("반복 일정이 아닙니다.");
         }
 
+        deleteLectureIfExists(eventToDelete);
         eventParticipantRawService.deleteAllByEvent(eventToDelete);
-
         recurringEventRawService.deleteRecurringEvent(eventToDelete);
+    }
+
+    private void deleteLectureIfExists(Event event) {
+        lectureRepository.findByEvent(event).ifPresent(lectureRepository::delete);
     }
 
 

--- a/backend/src/main/java/unischedule/lecture/repository/LectureRepository.java
+++ b/backend/src/main/java/unischedule/lecture/repository/LectureRepository.java
@@ -3,12 +3,13 @@ package unischedule.lecture.repository;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import unischedule.events.domain.Event;
 import unischedule.lecture.domain.Lecture;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface LectureRepository extends JpaRepository<Lecture, Long> {
@@ -21,5 +22,7 @@ public interface LectureRepository extends JpaRepository<Lecture, Long> {
     Set<Long> findAllEventIds(String email);
   
     List<Lecture> findByEventCalendarOwnerMemberIdAndEndDateGreaterThanEqual(Long memberId, LocalDate today);
+
+    Optional<Lecture> findByEvent(Event event);
 }
 


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- 수업으로 등록한 반복일정이 삭제되지 않는 버그 수정

# 어떻게 해결했나요?
- 반복일정 삭제 시 참조하고 있는 수업을 같이 삭제