### PR TITLE
refactor: 에브리타임 이미지 파싱 모델 gpt 4.1 mini로 재변경

### DIFF
--- a/backend/src/main/java/unischedule/external/OpenAiClient.java
+++ b/backend/src/main/java/unischedule/external/OpenAiClient.java
@@ -26,21 +26,59 @@ public class OpenAiClient {
         try {
             String base64Image = Base64.getEncoder().encodeToString(file.getBytes());
             Map<String, Object> request = Map.of(
-                    "model", "gpt-5-nano",
-                    "reasoning", Map.of("effort", "low"),
+                    "model", "gpt-4.1-mini",
                     "input", List.of(
                             Map.of("role", "user", "content", List.of(
                                     Map.of("type", "input_text", "text",
-                                                """
-                                                      너는 시간표 스크린샷 이미지를 입력받아 사용자에게 json으로 변환해주는 역할을 가지고 있어.
-                                                      이미지는 표로 구성되어있고, 행은 시간을 나타내고, 열은 요일을 나타내.
-                                                      입력받은 시간표 이미지를 표에 표시된 시간과 요일 및 아래 사항들에 유의하여 JSON으로 정확하게 변환해줘.
+                                            """
+                                                    너는 시간표 스크린샷 이미지를 입력받아 사용자에게 JSON으로 변환해주는 역할을 가지고 있어.
+                                                      이미지는 표로 구성되어 있고, 행은 시간을 나타내며, 열은 요일(월~금)을 나타낸다.
+                                                      입력받은 시간표 이미지를 기반으로, 아래 JSON 구조에 맞춰 내용을 정확하게 추출하여 변환한다.
                                                     
-                                                      1. 과목명, 교수, 요일, 시작/끝 시간, 장소 포함.
-                                                      2. 수업 시작 시간, 끝 시간은 정각이 아닐 수도 있어. 5분 간격임.
-                                                      3. 보이는 그대로 작성할 것. dayOfWeek는 월요일이 0임.
-                                                      4. 시간은 01:01 형식 유지. 시간 분 모두 2자리로 고정할 것. 24시간제 사용.
-                                                      5. 동일 수업(동일 색상)에 시간이 여러 개 있는 경우도 있어. 해당 경우 하나의 수업에 시간 list를 추가하는 방식으로 응답해야 함.
+                                                      ### 변환 규칙
+                                                    
+                                                      1. JSON은 다음 구조를 따른다.
+                                                    
+                                                      {
+                                                        "startDate": "",
+                                                        "endDate": "",
+                                                        "timetable": {
+                                                          "year": "",
+                                                          "semester": "",
+                                                          "subjects": [
+                                                            {
+                                                              "name": "과목명",
+                                                              "professor": "교수명",
+                                                              "credit": 3,
+                                                              "times": [
+                                                                {
+                                                                  "dayOfWeek": 1,
+                                                                  "startTime": "09:00:00",
+                                                                  "endTime": "10:15:00",
+                                                                  "place": "201-XXXX"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    
+                                                      단, `"startDate"`, `"endDate"`, `"year"`, `"semester"` 값은 이미지에 관련 정보가 없을 경우 빈 문자열("")로 두어도 된다.
+                                                    
+                                                      2. `"dayOfWeek"`는 월요일부터 1로 시작한다. (월=1, 화=2, 수=3, 목=4, 금=5)
+                                                    
+                                                      3. `"startTime"`, `"endTime"`은 `"HH:MM:SS"` 형식으로 표현하고, 24시간제를 사용한다. (예: 09:00:00 / 13:30:00)
+                                                    
+                                                      4. 동일한 과목명 + 교수명 + 강의실은 하나의 `"subject"`로 묶고
+                                                         `"times"` 리스트 안에 여러 요일별 시간 정보를 추가한다.
+                                                    
+                                                      5. `"credit"` 값은 명시되어 있지 않다면 일반 이론 과목은 3, 실습·실험 과목(‘실험’, ‘실습’, ‘프로젝트’, ‘캡스톤’ 등 포함)은 2로 추정한다.
+                                                    
+                                                      6. 이미지에 시간이 직접 표시되지 않는다면, 표의 격자 간격을 기준으로 상대적 시간대를 추정한다. (예: 한 칸=1시간이면 09:00–10:00 등)
+                                                    
+                                                      7. 모든 문자열은 정확히 이미지에서 보이는 그대로 입력한다. (과목명, 교수명, 강의실 번호, 요일 등)
+                                                    
+                                                      8. JSON 외의 다른 설명이나 텍스트는 절대 출력하지 않는다. 오직 JSON만 출력할 것
                                                     """),
                                     Map.of("type", "input_image", "image_url",
                                             "data:image/png;base64," + base64Image))
@@ -63,8 +101,10 @@ public class OpenAiClient {
                     .bodyToMono(JsonNode.class)
                     .handle((resp, sink) -> {
                         try {
-                            String content = resp.get("output").get(1).get("content").get(0).get("text").textValue();
-                            TimetableDetailDto result = objectMapper.readValue(content, TimetableDetailDto.class);
+                            String content = resp.get("output").get(0).get("content").get(0)
+                                    .get("text").textValue();
+                            TimetableDetailDto result = objectMapper.readValue(content,
+                                    TimetableDetailDto.class);
                             sink.next(result);
                         } catch (JsonProcessingException e) {
                             sink.error(new ExternalApiException("OpenAI API 응답 처리 실패"));


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
- 에브리타임 이미지 파싱 모델 gpt 4.1 mini로 재변경
- gpt5가 추론모델이라 응답 지연 및 정확도도 4.1에 비해 낮아 4.1 mini로 모델 재변경

# 어떻게 해결했나요?
- 에브리타임 이미지 파싱 모델 gpt 4.1 mini로 재변경