### PR TITLE
fix(config): make Oauth stateless (not require session) #164

### DIFF
--- a/backend/src/main/java/unischedule/common/config/SecurityConfig.java
+++ b/backend/src/main/java/unischedule/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package unischedule.common.config;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +12,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -72,7 +75,7 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/members/login", "/api/members/signup", "/api/members/refresh", "/ws/**", "/api/auth/email/send", "/api/auth/email/verify").permitAll()
                         .requestMatchers("/error", "/actuator/health", "/test").permitAll()
@@ -82,12 +85,33 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .oauth2Login(oauth -> oauth
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .authorizationRequestRepository(new StatelessAuthorizationRequestRepository()))
                         .successHandler(oAuth2LoginSuccessHandler)
                 )
                 .exceptionHandling(exceptions -> exceptions
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint())
                 );
         return http.build();
+    }
+
+    public static class StatelessAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+        @Override
+        public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+            return null;
+        }
+
+        @Override
+        public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+
+        }
+
+        @Override
+        public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+            return null;
+        }
+
     }
 }
 


### PR DESCRIPTION
# 연관된 이슈
- #164 

# 해결하려는 문제가 무엇인가요?
- Oauth인증이 stateful한 상태로 유지되는데 현재 session이 존재하지 않아 인증이 무조건 실패합니다.

# 어떻게 해결했나요?
- OAuth를 완전히 stateless하게 구성합니다.

# 어떤 부분에 집중하여 리뷰해야 할까요?
- 기존 API에 문제를 발생시키지 않는지 체크해야 합니다.
